### PR TITLE
Tika Search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Virtuoso files /data/db
 /data/db/*
 /data/elasticsearch/*
+/data/tika_cache/*
 !/data/db/virtuoso.ini
 !/data/db/toLoad
 !/data/db/toLoad/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging:
 
 services:
   toezicht-abb:
-    image: lblod/frontend-toezicht-abb:0.20.0
+    image: lblod/frontend-toezicht-abb:feature-tika-search
     links:
       - identifier:backend
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
     restart: always
     logging: *default-logging
   search:
-    image: semtech/mu-search:0.6.1
+    image: semtech/mu-search:pr-15
     volumes:
        - ./config/search:/config
        - ./data/files:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
     volumes:
        - ./config/search:/config
        - ./data/files:/data
+       - ./data/tika_cache:/cache
     environment:
       NUMBER_OF_THREADS: 4
       JRUBY_OPTIONS: "-J-Xmx8g" # overwrite for development


### PR DESCRIPTION
Enable search indexing through separated Tika implementation.

## What is this?

semtech/mu-search is building experimental support for an external Tika implementation.  This helps with faster indexing and lowers the general load on the system.  This PR seeks to solve that need.

Note that although we're now on a tagged build, this tag is still expected to receive updates in the coming weeks.

## Next steps

- [ ] Update frontend for API changes
  - [X] Frontend bulid to track changes (see lblod/frontend-toezicht-abb:feature-tika-search building at 2020/07/02/ 20:20:16)
- [ ] Use stable Tika search
  - [x] Wait for release of mu-semtech/mu-search#15 and pr-15 branch
  - [x] Update docker-compose mu-search image
  - [ ] Update frontend in case of changed API