### PR TITLE
bump search and mu-auth

### DIFF
--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -1,24 +1,16 @@
 export default [
-  // Problem with search, needs fixing first
-  // {
-  //   match: {
-  //     predicate: {
-  //       type: 'uri',
-  //       value: 'http://www.w3.org/ns/adms#status'
-  //     },
-  //     object: {
-  //       type: 'uri',
-  //       value: 'http://lblod.data.gift/concepts/d72999bf-2ef4-4332-bd6e-49c8a9e2498e'
-  //     }
-  //   },
-  //   callback: {
-  //     method: 'POST',
-  //     url: 'http://search/update',
-  //   },
-  //   options: {
-  //     resourceFormat: 'v0.0.1',
-  //     gracePeriod: 1000,
-  //     ignoreFromSelf: true
-  //   }
-  // }
+  {
+    match: {
+
+    },
+    callback: {
+      method: 'POST',
+      url: 'http://search/update'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true
+    }
+  }
 ];

--- a/config/migrations/20200709143000-remove-incorrect-concepts-from-inzending-type-codelist.sparql
+++ b/config/migrations/20200709143000-remove-incorrect-concepts-from-inzending-type-codelist.sparql
@@ -1,0 +1,12 @@
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    <https://data.vlaanderen.be/id/concept/BesluitType/4673d472-8dbc-4cea-b3ab-f92df3807eb3>
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5>;
+    <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> .
+
+    <https://data.vlaanderen.be/id/concept/BesluitType/4d8f678a-6fa4-4d5f-a2a1-80974e43bf34>
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5>;
+    <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> .
+ }
+}
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,3 +18,8 @@ services:
     ports:
       - "5601:5601"
     restart: "no"
+  search:
+    restart: "no"
+    environment:
+      NUMBER_OF_THREADS: 4 # overwrite for development
+      JRUBY_OPTIONS: "-J-Xmx8g" # overwrite for development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - "logging=true"
     logging: *default-logging
   database:
-    image: semtech/mu-authorization:0.6.0-beta.4
+    image: semtech/mu-authorization:0.6.0-beta.5
     environment:
       MU_SPARQL_ENDPOINT: "http://virtuoso:8890/sparql"
     volumes:
@@ -118,14 +118,13 @@ services:
     restart: always
     logging: *default-logging
   search:
-    image: semtech/mu-search:0.6.2
+    image: semtech/mu-search:0.6.3
     volumes:
        - ./config/search:/config
        - ./data/files:/data
     environment:
-      NUMBER_OF_THREADS: 4
-      JRUBY_OPTIONS: "-J-Xmx8g" # overwrite for development
-      # LOG_LEVEL: "info"
+      NUMBER_OF_THREADS: 16 # overwrite for development
+      JRUBY_OPTIONS: "-J-Xmx16g" # overwrite for development
     logging: *default-logging
     # labels:
     #  - "logging=true"


### PR DESCRIPTION
- this addresses the dropped connections during reindexing by using connection pools in mu-search
- this addresses the delta issue by using a newer version of mu-auth that properly handles ask queries
- adjusted the delta rules to sent all delta's to mu-search. (this is not a strict requirement at the moment, but sort of assumed in mu-search delta handling.)