### PR TITLE
bump musearch to latest version

### DIFF
--- a/config/search/config.json
+++ b/config/search/config.json
@@ -35,6 +35,14 @@
           "141d9d6b-54af-4d17-b313-8d1c30bc3f5b"
         ]
       }
+    ],
+    [
+      {
+        "name": "users",
+        "variables": [
+          "141d9d6b-54af-4d17-b313-8d1c30bc3f5b"
+        ]
+      }
     ]
   ],
   "default_settings": {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,6 +18,8 @@ services:
     ports:
       - "5601:5601"
     restart: "no"
+  tika:
+    restart: "no"
   search:
     restart: "no"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,22 +125,24 @@ services:
     restart: always
     logging: *default-logging
   search:
-    image: semtech/mu-search:0.6.3
+    image: semtech/mu-search:0.9.0-beta.6
     volumes:
       - ./config/search:/config
       - ./data/files:/data
+      - ./data/search/cache/:/cache
     environment:
       NUMBER_OF_THREADS: 16 # overwrite for development
       JRUBY_OPTIONS: "-J-Xmx16g" # overwrite for development
     restart: always
     logging: *default-logging
+  tika:
+    image: apache/tika:1.28.3-full
   elasticsearch:
     image: semtech/mu-search-elastic-backend:1.0.1
     volumes:
       - ./data/elasticsearch/:/usr/share/elasticsearch/data
     environment:
       - discovery.type=single-node
-      - http.max_content_length=2000MB
     restart: always
     logging: *default-logging
   enrich-submission:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging:
 
 services:
   toezicht-abb:
-    image: lblod/frontend-toezicht-abb:0.26.0
+    image: lblod/frontend-toezicht-abb:0.26.1
     volumes:
       - ./config/frontend:/config
     labels:


### PR DESCRIPTION
Note that this requires the indexes to be rebuild! The first time tika caches need to be constructed, which may take some time. The testing run (documented below) took about 5 hours

Can be tested locally with files (last 14 days) from loket using

```
rsync -az --progress abb-charlie:/data/app-toezicht-abb/data/db/ data/db/
rsync -az --progress --files-from=<(ssh abb-charlie 'find /data/app-digitaal-loket/data/files -mtime -14 -type f -maxdepth 1 -exec basename {} \;') abb-charlie:/data/app-digitaal-loket/data/files/ data/files/
```

Note that this will log a lot of errors about files not being found when testing, this is normal because you don't have all files, e.g.

```
app-toezicht-abb-search-1  | WARN INDEXING -- File /data/a3161170-2fe9-11eb-8cd1-cd547a5fd8e8.html not found. File content will not be indexed.
```

This PR supersedes #1 , needs frontend changes from https://github.com/lblod/frontend-toezicht-abb/pull/4/