### PR TITLE
Add cross referencing service and config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 - Add cross referencing service and config [#48]
 
 ### Deploy notes
+#### docker-compose.override.yml
+##### worship-decisions-cross-reference
+Ensure the environment variables are correctly set for `worship-decisions-cross-reference`, e.g. :
+
+```
+worship-decisions-cross-reference:
+  environment:
+    WORSHIP_DECISIONS_BASE_URL: "https://databankerediensten.lokaalbestuur.vlaanderen.be/search/submissions/"
+```
+The following links;
+- DEV: "https://dev.databankerediensten.lokaalbestuur.lblod.info/search/submissions/"
+- QA: "https://databankerediensten.lokaalbestuur.lblod.info/search/submissions/"
+- PROD: "https://databankerediensten.lokaalbestuur.vlaanderen.be/search/submissions/"
+
 #### Docker Commands
 - `drc restart migrations dispatcher`
 - `drc up -d worship-decisions-cross-reference`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+
+## Unreleased
+- Add cross referencing service and config [#48]
+
+### Deploy notes
+#### Docker Commands
+- `drc restart migrations dispatcher`
+- `drc up -d worship-decisions-cross-reference`
+
 ## v1.40.8 (2024-12-13)
 - New semantic form `Kerkenbeleidsplan`
 - New semantic forms for cross referencing

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -140,6 +140,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/concepts/"
   end
 
+  get "/worship-decisions-cross-reference/document-information/*path", @json do
+    Proxy.forward conn, path, "http://worship-decisions-cross-reference/document-information/"
+  end
+
   #################################################################
   # Review
   #################################################################

--- a/config/migrations/2024/20241217102700-submissions-crossreferencing/20241217102800-article-types.sparql
+++ b/config/migrations/2024/20241217102700-submissions-crossreferencing/20241217102800-article-types.sparql
@@ -1,0 +1,35 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX artikelTypes: <http://data.lblod.info/concepts/ArtikelTypes/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> a skos:ConceptScheme;
+        skos:definition "Lijst van type Artikels die binnen een Besluit kunnen getroffen worden.";
+        skos:prefLabel "Type Artikels";
+        skos:hasTopConcept
+        artikelTypes:c47c6ac9-1628-4378-9689-8caa7c6d7968,
+        artikelTypes:9a54a930-7dd6-4ff2-a4b1-ee403f7cda5c,
+        artikelTypes:773343c9-55a4-4aaa-942c-e3a048b35c1f,
+        artikelTypes:080def57-72ce-4f32-b3f9-369009644fd2 .
+
+    artikelTypes:c47c6ac9-1628-4378-9689-8caa7c6d7968 a skos:Concept;
+        skos:prefLabel "Verwerping gerefereerde documenten.";
+        skos:definition "Verwerping van de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+
+    artikelTypes:9a54a930-7dd6-4ff2-a4b1-ee403f7cda5c a skos:Concept;
+        skos:prefLabel "Goedkeuring gerefereerde documenten.";
+        skos:definition "Goedkeuring van de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+
+    artikelTypes:773343c9-55a4-4aaa-942c-e3a048b35c1f a skos:Concept;
+        skos:prefLabel "Aktename gerefereerde documenten.";
+        skos:definition "Aktename van de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+
+    artikelTypes:080def57-72ce-4f32-b3f9-369009644fd2 a skos:Concept;
+        skos:prefLabel "Aanpassingsverzoek gerefereerde documenten.";
+        skos:definition "Vraag om aanpassing van de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+    }
+}

--- a/config/migrations/2024/20241217102700-submissions-crossreferencing/20241217102900-update-article-types.sparql
+++ b/config/migrations/2024/20241217102700-submissions-crossreferencing/20241217102900-update-article-types.sparql
@@ -1,0 +1,82 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX artikelTypes: <http://data.lblod.info/concepts/ArtikelTypes/>
+
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> a skos:ConceptScheme;
+        skos:definition "Lijst van type Artikels die binnen een Besluit kunnen getroffen worden.";
+        skos:prefLabel "Type Artikels";
+        skos:hasTopConcept
+        artikelTypes:c47c6ac9-1628-4378-9689-8caa7c6d7968,
+        artikelTypes:9a54a930-7dd6-4ff2-a4b1-ee403f7cda5c,
+        artikelTypes:773343c9-55a4-4aaa-942c-e3a048b35c1f,
+        artikelTypes:080def57-72ce-4f32-b3f9-369009644fd2 .
+
+    artikelTypes:c47c6ac9-1628-4378-9689-8caa7c6d7968 a skos:Concept;
+        skos:prefLabel "Verwerping gerefereerde documenten.";
+        skos:definition "Verwerping van de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+
+    artikelTypes:9a54a930-7dd6-4ff2-a4b1-ee403f7cda5c a skos:Concept;
+        skos:prefLabel "Goedkeuring gerefereerde documenten.";
+        skos:definition "Goedkeuring van de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+
+    artikelTypes:773343c9-55a4-4aaa-942c-e3a048b35c1f a skos:Concept;
+        skos:prefLabel "Aktename gerefereerde documenten.";
+        skos:definition "Aktename van de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+
+    artikelTypes:080def57-72ce-4f32-b3f9-369009644fd2 a skos:Concept;
+        skos:prefLabel "Aanpassingsverzoek gerefereerde documenten.";
+        skos:definition "Vraag om aanpassing van de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+    }
+}
+
+;
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> a skos:ConceptScheme;
+        skos:definition "Lijst van type Artikels die binnen een Besluit kunnen getroffen worden.";
+        skos:prefLabel "Type Artikels";
+        skos:hasTopConcept
+        artikelTypes:c47c6ac9-1628-4378-9689-8caa7c6d7968,
+        artikelTypes:9a54a930-7dd6-4ff2-a4b1-ee403f7cda5c,
+        artikelTypes:773343c9-55a4-4aaa-942c-e3a048b35c1f,
+        artikelTypes:080def57-72ce-4f32-b3f9-369009644fd2,
+        artikelTypes:5e1beb14-142b-4394-b302-6648ad6f3e00,
+        artikelTypes:03bb19a1-5ada-4098-830e-936c1da367f5.
+
+    artikelTypes:c47c6ac9-1628-4378-9689-8caa7c6d7968 a skos:Concept;
+        skos:prefLabel "Ongunstig advies gerefereerde documenten.";
+        skos:definition "Ongunstig advies voor de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+
+    artikelTypes:9a54a930-7dd6-4ff2-a4b1-ee403f7cda5c a skos:Concept;
+        skos:prefLabel "Gunstig advies gerefereerde documenten.";
+        skos:definition "Gunstig advies voor de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+
+    artikelTypes:773343c9-55a4-4aaa-942c-e3a048b35c1f a skos:Concept;
+        skos:prefLabel "Niet goedkeuring gerefereerde documenten.";
+        skos:definition "Niet goedkeuring van de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+
+    artikelTypes:080def57-72ce-4f32-b3f9-369009644fd2 a skos:Concept;
+        skos:prefLabel "Goedkeuring gerefereerde documenten.";
+        skos:definition "Goedkeuring van de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+
+    artikelTypes:5e1beb14-142b-4394-b302-6648ad6f3e00 a skos:Concept;
+        skos:prefLabel "Aktename gerefereerde documenten.";
+        skos:definition "Aktename van de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+
+    artikelTypes:03bb19a1-5ada-4098-830e-936c1da367f5 a skos:Concept;
+        skos:prefLabel "Aanpassing gerefereerde documenten.";
+        skos:definition "Aanpassing van de documenten waarnaar gerefereerd wordt.";
+        skos:inScheme <http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6> .
+    }
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,3 +25,5 @@ services:
     environment:
       NUMBER_OF_THREADS: 4 # overwrite for development
       JRUBY_OPTIONS: "-J-Xmx8g" # overwrite for development
+  worship-decisions-cross-reference:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging:
 
 services:
   toezicht-abb:
-    image: lblod/frontend-toezicht-abb:0.28.2
+    image: lblod/frontend-toezicht-abb:0.29.0
     volumes:
       - ./config/frontend:/config
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,3 +183,9 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  worship-decisions-cross-reference:
+    image: lblod/worship-decisions-cross-reference-service:0.4.6
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging


### PR DESCRIPTION
[DL-6352]

# Context

We want to be able to properly display forms containing cross-referenced documents

# Testing

This PR needs to be tested with https://github.com/lblod/app-digitaal-loket/pull/624 and https://github.com/lblod/frontend-toezicht-abb/pull/51

1. In your local stack of Loket, create a submission including cross referencing
2. In Loket, run an export via updating the cron pattern in your `docker-compose.override.yml` as such:
```
  export-submissions:
    environment:
      EXPORT_CRON_PATTERN: "0 0 * * * *"
```
3. Add the following to the `docker-compose.override.yml` file of your Toezicht ABB stack:
```
version: '3.4'

services:
  file:
    volumes:
      - /path/to/Loket/app-digitaal-loket/data/files:/share
  search:
    volumes:
      - /path/to/Loket/app-digitaal-loket/data/files:/data
  import:
    volumes:
      - /path/to/Loket/app-digitaal-loket/data/exports/submissions:/data/imports
    environment:
      CRON_PATTERN: "0 * * * *"
  enrich-submission:
    volumes:
      - /path/to/app-digitaal-loket/data/files/submissions:/share/submissions
```
5. Update the `CRON_PATTERN` so that the import runs. :warning: the imported file needs to be more that 30 minutes old (and less than 24h), you can update its creation date via `touch -d "2 hours ago" ./path/to/file.ttl`
6. You should be able to open the submission and it should show the forms as they are in Loket