### PR TITLE
Add op public consumer to the application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Sync from OP public [DL-6394]
 
 ### Deploy notes
+
+WARNING The sync should be deployed after https://github.com/lblod/app-digitaal-loket/pull/631
+
 ```
 drc down;
 ```

--- a/config/migrations/2025/20250128092000-op-sync/20250129162300-flush-all-admin-units-before-sync-with-op.sparql
+++ b/config/migrations/2025/20250128092000-op-sync/20250129162300-flush-all-admin-units-before-sync-with-op.sparql
@@ -1,0 +1,591 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+#######################################################################
+# START
+# First remove the extra mappings.
+# This based on the conversion from the export.json of the op-producer.
+#######################################################################
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a ?type ;
+      ?p ?o.
+    VALUES ?type {
+      <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+      <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+      <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>
+      <http://www.w3.org/ns/regorg#RegisteredOrganization>
+      <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+      <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>
+      <http://data.lblod.info/vocabularies/erediensten/PositieBedienaar>
+      <http://www.w3.org/ns/org#Site>
+      <http://www.w3.org/ns/locn#Address>
+      <http://schema.org/ContactPoint>
+      <http://www.w3.org/ns/adms#Identifier>
+      <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>
+      <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>
+      <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>
+      <http://lblod.data.gift/vocabularies/organisatie/TypeEredienst>
+      <http://lblod.data.gift/vocabularies/organisatie/BestuursorgaanClassificatieCode>
+      <http://www.w3.org/ns/org#ChangeEvent>
+      <http://lblod.data.gift/vocabularies/organisatie/Veranderingsgebeurtenis>
+      <http://lblod.data.gift/vocabularies/organisatie/OrganisatieStatusCode>
+      <http://lblod.data.gift/vocabularies/organisatie/TypeVestiging>
+      <http://data.vlaanderen.be/ns/mandaat#Mandaat>
+      <http://data.lblod.info/vocabularies/leidinggevenden/Bestuursfunctie>
+    }
+    VALUES ?p {
+       <http://data.vlaanderen.be/ns/besluit#classificatie>
+       <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan>
+       <http://mu.semte.ch/vocabularies/ext/kbonummer>
+       <http://purl.org/dc/terms/identifier>
+    }
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
+      skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+     ?s a besluit:Bestuurseenheid.
+  }
+}
+
+;
+
+# Not flushing RO classification code for now. It's not yet produced by OP and
+# there is a big deploy queue on OP right now. We'll do it later.
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>.
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>.
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan> ;
+      <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuurseenheid;
+      <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
+  }
+}
+
+#######################################################################
+# END
+# First remove the extra mappings.
+# This based on the conversion from the export.json of the op-producer.
+#######################################################################
+
+#######################################################################
+# START
+# This is a conversion from the export.json of the op-producer.
+# If you need to re-init; check again export.json from the op-producer
+#######################################################################
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/2004/02/skos/core#prefLabel>
+      <http://www.w3.org/ns/regorg#legalName>
+      <http://www.w3.org/2004/02/skos/core#altLabel>
+      <http://www.w3.org/ns/adms#identifier>
+      <http://www.w3.org/ns/regorg#orgStatus>
+      <http://www.w3.org/ns/org#hasPrimarySite>
+      <http://www.w3.org/ns/org#hasSite>
+      <http://www.w3.org/ns/org#changedBy>
+      <http://www.w3.org/ns/org#resultedFrom>
+      <http://www.w3.org/ns/org#hasPost>
+      <http://www.w3.org/ns/org#linkedTo>
+      <http://www.w3.org/ns/org#hasSubOrganization>
+      <http://www.w3.org/ns/org#classification>
+      <http://data.lblod.info/vocabularies/erediensten/denominatie>
+      <http://data.lblod.info/vocabularies/erediensten/grensoverschrijdend>
+      <http://data.lblod.info/vocabularies/erediensten/wordtBediendDoor>
+      <http://data.lblod.info/vocabularies/erediensten/typeEredienst>
+    }
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/2004/02/skos/core#prefLabel>
+      <http://www.w3.org/ns/regorg#legalName>
+      <http://www.w3.org/2004/02/skos/core#altLabel>
+      <http://www.w3.org/ns/adms#identifier>
+      <http://www.w3.org/ns/regorg#orgStatus>
+      <http://www.w3.org/ns/org#hasPrimarySite>
+      <http://www.w3.org/ns/org#hasSite>
+      <http://www.w3.org/ns/org#changedBy>
+      <http://www.w3.org/ns/org#resultedFrom>
+      <http://www.w3.org/ns/org#hasPost>
+      <http://www.w3.org/ns/org#linkedTo>
+      <http://www.w3.org/ns/org#hasSubOrganization>
+      <http://www.w3.org/ns/org#classification>
+      <http://data.lblod.info/vocabularies/erediensten/typeEredienst>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur>
+      <http://data.lblod.info/vocabularies/erediensten/denominatie>
+      <http://data.lblod.info/vocabularies/erediensten/grensoverschrijdend>
+      <http://data.lblod.info/vocabularies/erediensten/typeEredienst>
+      <http://data.lblod.info/vocabularies/erediensten/wordtBediendDoor>
+      <http://data.vlaanderen.be/ns/besluit#werkingsgebied>
+      <http://www.opengis.net/ont/geosparql#sfWithin>
+      <http://www.w3.org/2002/07/owl#sameAs>
+      <http://www.w3.org/2004/02/skos/core#altLabel>
+      <http://www.w3.org/2004/02/skos/core#prefLabel>
+      <http://www.w3.org/ns/regorg#legalName>
+      <http://www.w3.org/ns/adms#identifier>
+      <http://www.w3.org/ns/org#changedBy>
+      <http://www.w3.org/ns/org#classification>
+      <http://www.w3.org/ns/org#hasPost>
+      <http://www.w3.org/ns/org#hasPrimarySite>
+      <http://www.w3.org/ns/org#hasSite>
+      <http://www.w3.org/ns/org#hasSubOrganization>
+      <http://www.w3.org/ns/org#linkedTo>
+      <http://www.w3.org/ns/org#resultedFrom>
+      <http://www.w3.org/ns/regorg#orgStatus>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://www.w3.org/ns/regorg#RegisteredOrganization> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://data.vlaanderen.be/ns/besluit#werkingsgebied>
+      <http://www.opengis.net/ont/geosparql#sfWithin>
+      <http://www.w3.org/2002/07/owl#sameAs>
+      <http://www.w3.org/2004/02/skos/core#altLabel>
+      <http://www.w3.org/2004/02/skos/core#prefLabel>
+      <http://www.w3.org/ns/regorg#legalName>
+      <http://www.w3.org/ns/adms#identifier>
+      <http://www.w3.org/ns/org#changedBy>
+      <http://www.w3.org/ns/org#classification>
+      <http://www.w3.org/ns/org#hasPost>
+      <http://www.w3.org/ns/org#hasPrimarySite>
+      <http://www.w3.org/ns/org#hasSite>
+      <http://www.w3.org/ns/org#hasSubOrganization>
+      <http://www.w3.org/ns/org#linkedTo>
+      <http://www.w3.org/ns/org#resultedFrom>
+      <http://www.w3.org/ns/regorg#orgStatus>
+      <https://data.lblod.info/vocabularies/generiek/geplandeEindDatum>
+      <http://www.w3.org/ns/org#purpose>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/2004/02/skos/core#prefLabel>
+      <http://www.w3.org/ns/regorg#legalName>
+      <http://www.w3.org/2004/02/skos/core#altLabel>
+      <http://www.w3.org/ns/org#linkedTo>
+      <http://data.lblod.info/vocabularies/erediensten/typeEredienst>
+      <http://www.w3.org/ns/org#classification>
+      <http://www.w3.org/ns/adms#identifier>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid>
+      <http://www.w3.org/ns/org#organization>
+      <http://data.lblod.info/vocabularies/erediensten/financieringspercentage>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://data.lblod.info/vocabularies/erediensten/PositieBedienaar> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/ns/org#role>
+      <http://data.lblod.info/vocabularies/erediensten/functie>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://www.w3.org/ns/org#Site> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/ns/org#siteAddress>
+      <https://data.vlaanderen.be/ns/organisatie#bestaatUit>
+      <http://data.lblod.info/vocabularies/erediensten/vestigingstype>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://www.w3.org/ns/locn#Address> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer>
+      <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer>
+      <http://www.w3.org/ns/locn#thoroughfare>
+      <http://www.w3.org/ns/locn#postCode>
+      <https://data.vlaanderen.be/ns/adres#gemeentenaam>
+      <http://www.w3.org/ns/locn#adminUnitL2>
+      <https://data.vlaanderen.be/ns/adres#land>
+      <http://www.w3.org/ns/locn#fullAddress>
+      <https://data.vlaanderen.be/ns/adres#verwijstNaar>
+      <http://purl.org/dc/terms/source>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://schema.org/ContactPoint> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/ns/locn#address>
+      <http://xmlns.com/foaf/0.1/page>
+      <http://schema.org/faxNumber>
+      <http://schema.org/contactType>
+      <http://xmlns.com/foaf/0.1/page>
+      <http://schema.org/email>
+      <http://schema.org/telephone>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://www.w3.org/ns/adms#Identifier> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/2004/02/skos/core#notation>
+      <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://www.w3.org/ns/adms#Identifier> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/2004/02/skos/core#notation>
+      <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/2004/02/skos/core#prefLabel>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://data.vlaanderen.be/ns/besluit#bestuurt>
+      <http://www.w3.org/ns/org#classification>
+      <http://data.vlaanderen.be/ns/mandaat#bindingEinde>
+      <http://data.vlaanderen.be/ns/mandaat#bindingStart>
+      <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan>
+      <http://www.w3.org/ns/org#hasPost>
+      <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://lblod.data.gift/vocabularies/organisatie/TypeEredienst> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/2004/02/skos/core#prefLabel>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuursorgaanClassificatieCode> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/2004/02/skos/core#prefLabel>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://www.w3.org/ns/org#ChangeEvent> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://purl.org/dc/terms/date>
+      <http://purl.org/dc/terms/description>
+      <http://data.lblod.info/vocabularies/contacthub/typeWijziging>
+      <http://www.w3.org/ns/org#resultedFrom>
+      <http://www.w3.org/ns/org#changedBy>
+      <http://lblod.data.gift/vocabularies/organisatie/veranderingsgebeurtenisResultaat>
+      <http://www.w3.org/ns/org#originalOrganization>
+      <http://www.w3.org/ns/org#resultingOrganization>
+      <http://data.europa.eu/m8g/hasFormalFramework>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://lblod.data.gift/vocabularies/organisatie/Veranderingsgebeurtenis> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/2004/02/skos/core#prefLabel>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://lblod.data.gift/vocabularies/organisatie/OrganisatieStatusCode> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/2004/02/skos/core#prefLabel>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://lblod.data.gift/vocabularies/organisatie/TypeVestiging> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/2004/02/skos/core#prefLabel>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://data.vlaanderen.be/ns/mandaat#Mandaat> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/ns/org#role>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { ?s ?p ?o. }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Bestuursfunctie> ;
+       ?p ?o.
+    VALUES ?p {
+      <http://mu.semte.ch/vocabularies/core/uuid>
+      <http://www.w3.org/ns/org#role>
+      <http://www.w3.org/2004/02/skos/core#prefLabel>
+    }
+  }
+};
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a ?type .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?s a ?type .
+    VALUES ?type {
+      <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+      <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+      <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>
+      <http://www.w3.org/ns/regorg#RegisteredOrganization>
+      <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+      <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>
+      <http://data.lblod.info/vocabularies/erediensten/PositieBedienaar>
+      <http://www.w3.org/ns/org#Site>
+      <http://www.w3.org/ns/locn#Address>
+      <http://schema.org/ContactPoint>
+      <http://www.w3.org/ns/adms#Identifier>
+      <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>
+      <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>
+      <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>
+      <http://lblod.data.gift/vocabularies/organisatie/TypeEredienst>
+      <http://lblod.data.gift/vocabularies/organisatie/BestuursorgaanClassificatieCode>
+      <http://www.w3.org/ns/org#ChangeEvent>
+      <http://lblod.data.gift/vocabularies/organisatie/Veranderingsgebeurtenis>
+      <http://lblod.data.gift/vocabularies/organisatie/OrganisatieStatusCode>
+      <http://lblod.data.gift/vocabularies/organisatie/TypeVestiging>
+      <http://data.vlaanderen.be/ns/mandaat#Mandaat>
+      <http://data.lblod.info/vocabularies/leidinggevenden/Bestuursfunctie>
+    }
+  }
+}
+#######################################################################
+# END
+# This is a conversion from the export.json of the op-producer.
+# If you need to re-init; check again export.json from the op-producer
+#######################################################################

--- a/config/op-consumer/mapping/queries/README.md
+++ b/config/op-consumer/mapping/queries/README.md
@@ -1,0 +1,2 @@
+Example configuration for Organization Portal (PUBLIC) to Loket.
+It contains some mappings which are not used in the public producer (such as names of persons) but does not yet take all the necessary mapping into account yet for a sensitive data in OP. Mainly the pass configuration should be extended.

--- a/config/op-consumer/mapping/queries/op2dl/identifier/identifier-kbo.rq
+++ b/config/op-consumer/mapping/queries/op2dl/identifier/identifier-kbo.rq
@@ -1,0 +1,23 @@
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX persoon: <https://data.vlaanderen.be/ns/persoon#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+
+CONSTRUCT {
+  ?bestuurseenheid dcterms:identifier ?kboNummer.
+}
+WHERE {
+  ?identifier
+    skos:notation "KBO nummer";
+    generiek:gestructureerdeIdentificator ?gestructureerdeIdentificator.
+
+  ?gestructureerdeIdentificator
+    generiek:lokaleIdentificator ?kboNummer.
+
+  ?bestuurseenheid
+    adms:identifier ?identifier.
+}

--- a/config/op-consumer/mapping/queries/op2dl/identifier/identifier-ovo.rq
+++ b/config/op-consumer/mapping/queries/op2dl/identifier/identifier-ovo.rq
@@ -1,0 +1,19 @@
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX skos:<http://www.w3.org/2004/02/skos/core#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+CONSTRUCT {
+  ?bestuurseenheid dcterms:identifier ?ovoNummer.
+}
+WHERE {
+  ?identifier
+    skos:notation "OVO-nummer";
+    generiek:gestructureerdeIdentificator ?gestructureerdeIdentificator.
+
+  ?gestructureerdeIdentificator
+    generiek:lokaleIdentificator ?ovoNummer.
+
+  ?bestuurseenheid
+    adms:identifier ?identifier.
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/bestuurVanDeEredienst.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/bestuurVanDeEredienst.sparql
@@ -1,0 +1,11 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+CONSTRUCT {
+  ?s a besluit:Bestuurseenheid, ere:BestuurVanDeEredienst;
+    skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
+    skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
+} WHERE {
+  ?s a ere:BestuurVanDeEredienst.
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/bestuurseenheid.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/bestuurseenheid.sparql
@@ -1,0 +1,10 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+CONSTRUCT {
+  ?s skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
+    skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
+} WHERE {
+  ?s a besluit:Bestuurseenheid.
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/bestuursorgaanLabel.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/bestuursorgaanLabel.sparql
@@ -1,0 +1,18 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+CONSTRUCT {
+  ?bestuursorgaan skos:prefLabel ?bestuursorgaanLabel.
+} WHERE {
+  ?bestuursorgaan
+    besluit:bestuurt ?bestuurseenheid;
+    org:classification ?classificatie.
+
+  ?classificatie
+    skos:prefLabel ?classificatieLabel.
+  ?bestuurseenheid
+    skos:prefLabel ?bestuurseenheidLabel.
+
+  BIND(CONCAT(str(?classificatieLabel), " ", str(?bestuurseenheidLabel)) as ?bestuursorgaanLabel)
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/centraalBestuurVanDeEredienst.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/centraalBestuurVanDeEredienst.sparql
@@ -1,0 +1,11 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+CONSTRUCT {
+  ?s a besluit:Bestuurseenheid, ere:CentraalBestuurVanDeEredienst;
+    skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
+    skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
+} WHERE {
+  ?s a ere:CentraalBestuurVanDeEredienst.
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/classification.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/classification.sparql
@@ -1,0 +1,15 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+CONSTRUCT {
+  ?s besluit:classificatie ?o .
+} WHERE {
+  ?s org:classification ?o .
+
+  # The consumers currently don't support the OCMWv subcategories, special mapping rules are needed.
+  # See mapping-ocmwv.sparql
+  FILTER (?o NOT IN
+    ( <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267>,
+      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9>
+    ))
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/ext-bestuurseenheid-classificatie-code.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/ext-bestuurseenheid-classificatie-code.sparql
@@ -1,0 +1,5 @@
+CONSTRUCT {
+  ?s a <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>.
+} WHERE {
+  ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>.
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/ext-representatief-orgaan-code.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/ext-representatief-orgaan-code.sparql
@@ -1,0 +1,5 @@
+CONSTRUCT {
+  ?s a <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>.
+} WHERE {
+  ?s a <http://mu.semte.ch/vocabularies/ext/RepresentatiefOrgaanClassificatieCode>.
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/isTijdspecialisatieVan.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/isTijdspecialisatieVan.sparql
@@ -1,0 +1,8 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+CONSTRUCT {
+  ?s mandaat:isTijdspecialisatieVan ?o.
+} WHERE {
+  ?s generiek:isTijdspecialisatieVan ?o.
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/mapping-ocmwv.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/mapping-ocmwv.sparql
@@ -1,0 +1,14 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+CONSTRUCT {
+  ?s besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089> .
+} WHERE {
+  ?s org:classification ?o .
+
+  # The consumers currently don't support the OCMWv subcategories
+  FILTER (?o IN
+    ( <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267>,
+      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9>
+    ))
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/municipality.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/municipality.sparql
@@ -1,0 +1,11 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+CONSTRUCT {
+  ?s skos:inScheme <http://lblod.data.gift/concept-schemes/dcfb437e-1219-4d1e-891d-057f262da9d6> .
+} WHERE {
+  ?s a besluit:Bestuurseenheid ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> .
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/representatief-orgaan-classification-code.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/representatief-orgaan-classification-code.sparql
@@ -1,0 +1,18 @@
+# Toezicht uses a "mock" RO classification that has the format of a bestuurseenheid classification code
+# to fit with the rest of the application
+CONSTRUCT {
+  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213>
+    a <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>,
+      <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>,
+      <http://www.w3.org/2004/02/skos/core#Concept>;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "36372fad-0358-499c-a4e3-f412d2eae213";
+    ?p ?o .
+} WHERE {
+  <http://data.vlaanderen.be/id/concept/RepresentatiefOrgaanClassificatieCode/89a00b5a-024f-4630-a722-65a5e68967e5> ?p ?o .
+
+  FILTER(?p NOT IN (
+    <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>,
+    <http://mu.semte.ch/vocabularies/core/uuid>
+  ))
+}

--- a/config/op-consumer/mapping/queries/op2dl/mapping/representatiefOrgaan.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/mapping/representatiefOrgaan.sparql
@@ -1,0 +1,11 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+CONSTRUCT {
+  ?s a besluit:Bestuurseenheid;
+    besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213>;
+    skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
+    skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
+} WHERE {
+  ?s <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/RepresentatiefOrgaanClassificatieCode/89a00b5a-024f-4630-a722-65a5e68967e5>.
+}

--- a/config/op-consumer/mapping/queries/op2dl/pass/bestuurseenheid.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/bestuurseenheid.sparql
@@ -1,0 +1,23 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+CONSTRUCT {
+  ?s ?p ?o.
+} WHERE {
+  ?s a besluit:Bestuurseenheid;
+    ?p ?o.
+
+  FILTER (?p IN (
+    <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>,
+    mu:uuid,
+    skos:prefLabel,
+    besluit:werkingsgebied,
+    besluit:classificatie,
+    dct:identifier,
+    skos:altLabel,
+    ere:betrokkenBestuur
+  ))
+}

--- a/config/op-consumer/mapping/queries/op2dl/pass/bestuursorgaan.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/bestuursorgaan.sparql
@@ -1,0 +1,22 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+CONSTRUCT {
+  ?s ?p ?o.
+} WHERE {
+  ?s a besluit:Bestuursorgaan;
+    ?p ?o.
+
+  FILTER (?p IN (
+    <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>,
+    mu:uuid,
+    skos:prefLabel,
+    mandaat:bindingEinde,
+    mandaat:bindingStart,
+    besluit:bestuurt,
+    besluit:classificatie,
+    mandaat:isTijdspecialisatieVan
+  ))
+}

--- a/config/op-consumer/mapping/queries/op2dl/pass/betrokken-lokale-besturen.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/betrokken-lokale-besturen.sparql
@@ -1,0 +1,18 @@
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+CONSTRUCT {
+  ?s ?p ?o.
+} WHERE {
+  ?s a ere:BetrokkenLokaleBesturen;
+    ?p ?o.
+
+  FILTER (?p IN (
+    <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>,
+    mu:uuid,
+    ere:financieringspercentage,
+    ere:typebetrokkenheid,
+    org:organization
+  ))
+}

--- a/config/op-consumer/mapping/queries/op2dl/pass/pass-all-properties.sparql
+++ b/config/op-consumer/mapping/queries/op2dl/pass/pass-all-properties.sparql
@@ -1,0 +1,18 @@
+CONSTRUCT {
+  ?s ?p ?o .
+}  
+WHERE {
+  ?s ?p ?o .
+
+  FILTER EXISTS {
+    ?s a ?type .
+
+    VALUES ?type {
+      <http://www.w3.org/2004/02/skos/core#Concept>
+      <http://mu.semte.ch/vocabularies/ext/BestuursorgaanClassificatieCode>
+      <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>
+      <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>
+      <http://mu.semte.ch/vocabularies/ext/OrganizationClassificationCode>
+    }
+  }
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,3 +27,5 @@ services:
       JRUBY_OPTIONS: "-J-Xmx8g" # overwrite for development
   worship-decisions-cross-reference:
     restart: "no"
+  op-public-consumer:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,3 +189,36 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
+  ################################################################################
+  # DELTA CONSUMERS
+  ################################################################################
+  ################################################################################
+  # OP PUBLIC CONSUMER
+  ################################################################################
+  op-public-consumer:
+    image: lblod/delta-consumer:0.1.0
+    environment:
+      DCR_SERVICE_NAME: "op-public-consumer"
+      DCR_SYNC_BASE_URL: "https://organisaties.abb.lblod.info" # replace with link to OP API
+      DCR_SYNC_FILES_PATH: "/sync/public/files"
+      DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/PublicCacheGraphDump"
+      DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/op-public"
+      DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/deltaSync/op-public"
+      DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/op-public-consumer"
+      DCR_DISABLE_INITIAL_SYNC: "true"
+      DCR_KEEP_DELTA_FILES: "true"
+      DCR_DELTA_JOBS_RETENTION_PERIOD: "30"
+      DCR_ENABLE_TRIPLE_REMAPPING: "true"
+      DCR_LANDING_ZONE_GRAPH: "http://mu.semte.ch/graphs/landing-zone/op-public"
+      DCR_REMAPPING_GRAPH: "http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b"
+      DCR_BATCH_SIZE: 1000
+      SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: "404,500,503"
+      SUDO_QUERY_RETRY: "true"
+    volumes:
+      - ./config/op-consumer/mapping:/config/mapping
+      - ./data/files/consumer-files/op-public:/consumer-files/
+    restart: always
+    labels:
+      - "logging=true"
+    logging: *default-logging


### PR DESCRIPTION
:warning: It should be deployed after https://github.com/lblod/app-digitaal-loket/pull/631 to avoid having to re-do the flush & sync :warning: 

# Context

In the context of DL-6394, we want to set up the automatic sync from OP to Toezicht ABB. Until now, data was incoming from an export of Loket. The flaw that caused the bug described in the ticket is that this import doesn't allow updates, it only inserts. We ended up with administrative units with multiple labels.

# How to test

You can find the set-up instructions in the Changelog and in the Readme. If you wire it to the DEV OP, you should be able to do updates / create new admin units and be able to select them in Toezicht ABB.

# Notes

## ext:inProvincie

I saw that admin units have most of a time a `ext:inProvincie` triple, that is not produced by OP. It doesn't seem to be used but it's defined in the backend and frontend models of Toezicht ABB. I decided to leave it as-is (so I didn't flush it). If the reviewer(s) think we should, it's not too late to flush it too!

## RepresentatiefOrgaanClassificatieCode

The classification of RO is defined in OP with the URI <http://data.vlaanderen.be/id/concept/RepresentatiefOrgaanClassificatieCode/89a00b5a-024f-4630-a722-65a5e68967e5>. This is not a `BestuurseenheidClassificatieCode` by definition, but something a little different. The tricky bit in the Loket/Toezicht realm is that all the apps are built on `BestuurseenheidClassificatieCode` and changing that would need a refactoring that is not on the top of the priorities currently, so those apps use a "fake" `BestuurseenheidClassificatieCode` to describe ROs and still be able to show the classification in dropdowns for example. This is why the file `representatief-orgaan-classification-code.sparql` exists, it ensures that the mock classification exists.