### PR TITLE
Submission data visible (Beveren-Kruibeke-Zwijndrecht)

### DIFF
--- a/config/migrations/2025/20250218150421-delete-broken-dct-source-triples.sparql
+++ b/config/migrations/2025/20250218150421-delete-broken-dct-source-triples.sparql
@@ -1,0 +1,26 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+
+# Due to a previous bug, this submission had more dct:source triples attached to it then it should have. 
+# This query deletes dct:source triples that are not in the list taken from app-digitaal-loket
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { # Beveren-Kruibeke-Zwijndrecht 
+    <https://data.beveren.be/id/besluiten/24.1219.9329.4965> dct:source ?o.
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> { # Beveren-Kruibeke-Zwijndrecht 
+    <https://data.beveren.be/id/besluiten/24.1219.9329.4965> dct:source ?o.
+    
+    FILTER (
+      ?o NOT IN (
+        <share://semantic-forms/20241122103645-forms.ttl>,
+        <share://submissions/cffdc301-dcaa-11ef-be0f-df08d94b1ed9.ttl>,
+        <share://submissions/cc153e30-dcaa-11ef-9619-dd6560b7b0d1.ttl>,
+        <share://submissions/ce397dc1-dcaa-11ef-9143-0fd9176d3ded.ttl>,
+        <share://submissions/1d592891-dcad-11ef-be0f-df08d94b1ed9.ttl>,
+        <share://submissions/1d655d91-dcad-11ef-be0f-df08d94b1ed9.ttl>
+      )
+    )
+  }
+}


### PR DESCRIPTION
## ID
DL-6430

## Description
The following submission could not be viewed in toezicht frontend

## Type of change

 - [x] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup
Pull in PRD data, then up the stack making sure that the migrations have ran completely

## How to test
- Login to app
- mock-login editeur
- go to the following URL `http://localhost:81/supervision/submissions/c7ec06e0-dcaa-11ef-9e12-c339e04edc63?bestuurseenheidIds=19483103-318e-435a-aa37-45e485406ee9`
- The submission should be visible. 
-> if you see a white screen instead then something is wrong