### PR TITLE
Bump Some Services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+- Bump `migrations` and `mock-login` services
+
+### Deploy Notes
+
+When deploying on servers not using mock-login:
+```
+drc up -d migrations
+```
+
+When deploying locally and on servers using mock-login:
+```
+drc up -d mocklogin
+```
+
 ## v1.42.0 (2025-02-27)
 
 - Sync from OP public [DL-6394]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ drc up -d migrations
 
 When deploying locally and on servers using mock-login:
 ```
-drc up -d mocklogin
+drc up -d migrations mocklogin
 ```
 
 ## v1.42.0 (2025-02-27)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   identifier:
     ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "81:80"
   mocklogin:
-    image: lblod/mock-login-service:0.4.0
+    image: lblod/mock-login-service:0.7.0
     environment:
       MU_APPLICATION_GRAPH: "http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b" # ABB
   virtuoso:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 x-logging:
   &default-logging
   driver: "json-file"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     restart: always
     logging: *default-logging
   migrations:
-    image: semtech/mu-migrations-service:0.6.0
+    image: semtech/mu-migrations-service:0.9.0
     environment:
       MU_SPARQL_TIMEOUT: '300'
     links:


### PR DESCRIPTION
## Description

* Bring some services to their most recent versions.
* Remove obsolete `version` attributes from the regular and dev docker compose config files since every instance of running `docker compose` will output:
```
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```