### PR TITLE
Add migration to remove document from a submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased (hotfix)
+
+### General
+
+- Remove document in submission from Gemeente Avelgem [DL-6691]
+
+### Deploy Notes
+
+```
+drc restart migrations && drc logs -ft --tail=200 migrations
+```
+
 ## v1.46.0 (2025-06-12)
 
 ### General

--- a/config/migrations/2025/20250618091500-remove-document-from-submission-avelgem.sparql
+++ b/config/migrations/2025/20250618091500-remove-document-from-submission-avelgem.sparql
@@ -1,0 +1,20 @@
+DELETE {
+  GRAPH ?g {
+    ?formData <http://purl.org/dc/terms/hasPart> ?remoteDataObject .
+    ?remoteDataObject ?p ?o .
+    ?file ?pfile ?ofile .
+  }
+} WHERE {
+  GRAPH ?g {
+    VALUES ?remoteDataObject {
+      <http://data.lblod.info/id/remote-data-objects/017b1550-3fa6-11f0-9619-dd6560b7b0d1>
+    }
+
+    ?formData <http://purl.org/dc/terms/hasPart> ?remoteDataObject .
+
+    ?remoteDataObject ?p ?o .
+
+    ?file <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource> ?remoteDataObject ;
+      ?pfile ?ofile .
+  }
+}


### PR DESCRIPTION
# Context

[DL-6691]

Gemeente Avelgem asked for a document to be removed from a submission.
To be deployed together with TODO

# How to test

Get yourself a prod backup, download the necessary submission files:
```
rsync -e ssh -avz -P root@abb-charlie.s.redpencil.io:/data/app-digitaal-loket/data/files/submissions/05d03ea1-3fa6-11f0-be0f-df08d94b1ed9.ttl ./data/files/submissions/
rsync -e ssh -avz -P root@abb-charlie.s.redpencil.io:/data/app-digitaal-loket/data/files/submissions/03bd3d21-3fa6-11f0-a5e1-15d64e5bdcee.ttl ./data/files/submissions/
```
and simply
```
drc restart migrations
```

The link to the document should not be visible anymore in the frontend.