### PR TITLE
feature/use correct province data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Virtuoso files /data/db
 /data/db/*
 /data/elasticsearch/*
+/data/search/cache
+/data/files/*
 /data/db/virtuoso.ini
 !/data/db/toLoad
 !/data/db/toLoad/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+## Unreleased
+- Ensure the updated data model of provinces is used. See also: DL-6429
+
+### Deploy Notes
+```
+drc restart migrations # Wait for correct finish.
+drc restart op-public-consumer dispatcher resource
+drc up -d
+/bin/bash scripts/reset-elastic.sh
+```
 
 ## v1.46.0 (2025-06-12)
 

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -69,7 +69,8 @@ defmodule Acl.UserGroups.Config do
                         "http://mu.semte.ch/vocabularies/ext/SubmissionReviewStatus",
                         "http://schema.org/Review",
                         "http://mu.semte.ch/vocabularies/ext/supervision/InzendingVoorToezicht", # still needed to be able to redirect old URLs correctly
-                        "http://lblod.data.gift/vocabularies/search-queries-toezicht/SearchQuery"
+                        "http://lblod.data.gift/vocabularies/search-queries-toezicht/SearchQuery",
+                        "http://www.w3.org/ns/org#Site"
                       ]
                     } } ] },
       %GroupSpec{

--- a/config/delta-consumers/op-consumer/mapping/queries/op2dl/pass/address.sparql
+++ b/config/delta-consumers/op-consumer/mapping/queries/op2dl/pass/address.sparql
@@ -1,0 +1,29 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX locn: <http://www.w3.org/ns/locn#>
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
+
+CONSTRUCT {
+  ?s ?p ?o.
+} WHERE {
+  ?s a locn:Address;
+    ?p ?o.
+
+  FILTER (?p IN (
+    <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>,
+    mu:uuid,
+    adres:Adresvoorstelling.busnummer,
+    adres:AdresVoorstelling.huisnummer,
+    locn:thoroughfare,
+    adres:gemeentenaam,
+    adres:land,
+    locn:locatorDesignator,
+    locn:locatorName,
+    locn:poBox,
+    locn:postName,
+    locn:fullAddress,
+    lblodlg:adresRegisterId,
+    adres:verwijstNaar,
+    adres:adresIsGelegenIn
+  ))
+}

--- a/config/delta-consumers/op-consumer/mapping/queries/op2dl/pass/bestuurseenheid.sparql
+++ b/config/delta-consumers/op-consumer/mapping/queries/op2dl/pass/bestuurseenheid.sparql
@@ -3,6 +3,7 @@ PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX org: <http://www.w3.org/ns/org#>
 
 CONSTRUCT {
   ?s ?p ?o.
@@ -18,6 +19,7 @@ CONSTRUCT {
     besluit:classificatie,
     dct:identifier,
     skos:altLabel,
-    ere:betrokkenBestuur
+    ere:betrokkenBestuur,
+    org:hasPrimarySite
   ))
 }

--- a/config/delta-consumers/op-consumer/mapping/queries/op2dl/pass/site.sparql
+++ b/config/delta-consumers/op-consumer/mapping/queries/op2dl/pass/site.sparql
@@ -1,0 +1,17 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX schema: <http://schema.org/>
+PREFIX organisatie: <https://data.vlaanderen.be/ns/organisatie#>
+
+CONSTRUCT {
+  ?s ?p ?o.
+} WHERE {
+  ?s a org:Site;
+    ?p ?o.
+
+  FILTER (?p IN (
+    <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>,
+    mu:uuid,
+    organisatie:bestaatUit
+  ))
+}

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -44,7 +44,12 @@ defmodule Dispatcher do
   get "/files/*path", @json do
     Proxy.forward conn, path, "http://resource/files/"
   end
-
+  get "/adressen/*path", @json do
+    Proxy.forward conn, path, "http://cache/adressen/" # TODO change back to cache
+  end
+  get "/vestigingen/*path", @json do
+    Proxy.forward conn, path, "http://cache/vestigingen/"
+  end
   ###############################################################
   # Searching
   ###############################################################

--- a/config/migrations/2025/20250701092801-add-is-gelegen-in-triples.sparql
+++ b/config/migrations/2025/20250701092801-add-is-gelegen-in-triples.sparql
@@ -1,0 +1,32 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX organisatie: <https://data.vlaanderen.be/ns/organisatie#>
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX schema: <http://schema.org/>
+PREFIX locn: <http://www.w3.org/ns/locn#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    ?bestuurseenheid org:hasPrimarySite ?primarySite .
+
+    ?primarySite a org:Site .
+    ?primarySite mu:uuid ?primarySiteUuid .
+    ?primarySite organisatie:bestaatUit ?address .
+
+    ?address a locn:Address .
+    ?address mu:uuid ?addressId .
+    ?address adres:adresIsGelegenIn ?provincie .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
+    ?bestuurseenheid org:hasPrimarySite ?primarySite .
+
+    ?primarySite a org:Site .
+    ?primarySite mu:uuid ?primarySiteUuid .
+    ?primarySite organisatie:bestaatUit ?address .
+
+    ?address a locn:Address .
+    ?address mu:uuid ?addressId .
+    ?address adres:adresIsGelegenIn ?provincie .
+  }
+}

--- a/config/migrations/2025/20250708111026-remove-unused-province-triples.sparql
+++ b/config/migrations/2025/20250708111026-remove-unused-province-triples.sparql
@@ -3,6 +3,5 @@ PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 DELETE WHERE {
   GRAPH ?g {
     ?bestuurseenheid ext:inProvincie ?werkingsgebied .
-    ?werkingsgebied ?p ?o .
   }
 }

--- a/config/migrations/2025/20250708111026-remove-unused-province-triples.sparql
+++ b/config/migrations/2025/20250708111026-remove-unused-province-triples.sparql
@@ -1,0 +1,8 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE WHERE {
+  GRAPH ?g {
+    ?bestuurseenheid ext:inProvincie ?werkingsgebied .
+    ?werkingsgebied ?p ?o .
+  }
+}

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -12,6 +12,8 @@
 (defparameter sparql:*experimental-no-application-graph-for-sudo-select-queries* t)
 
 (read-domain-file "slave-toezicht-domain.lisp")
+(read-domain-file "slave-organisatie-domain.lisp")
+(read-domain-file "slave-contact-domain.lisp")
 (read-domain-file "slave-files-domain.lisp")
 (read-domain-file "slave-besluit-domain.lisp")
 (read-domain-file "slave-users-domain.lisp")

--- a/config/resources/repository.lisp
+++ b/config/resources/repository.lisp
@@ -41,3 +41,6 @@
 
 (add-prefix "searchToezicht" "http://lblod.data.gift/vocabularies/search-queries-toezicht/")
 (add-prefix "toezicht" "http://mu.semte.ch/vocabularies/ext/supervision/")
+(add-prefix "organisatie" "https://data.vlaanderen.be/ns/organisatie#")
+(add-prefix "adres" "https://data.vlaanderen.be/ns/adres#")
+(add-prefix "locn" "http://www.w3.org/ns/locn#")

--- a/config/resources/slave-besluit-domain.lisp
+++ b/config/resources/slave-besluit-domain.lisp
@@ -91,6 +91,8 @@
                              :as "werkingsgebied")
              (werkingsgebied :via ,(s-prefix "ext:inProvincie")
                              :as "provincie")
+             (vestiging      :via ,(s-prefix "org:hasPrimarySite")
+                             :as "primary-site")
              (bestuurseenheid-classificatie-code :via ,(s-prefix "besluit:classificatie")
                                                  :as "classificatie"))
   :has-many `((contact-punt :via ,(s-prefix "schema:contactPoint")

--- a/config/resources/slave-besluit-domain.lisp
+++ b/config/resources/slave-besluit-domain.lisp
@@ -89,8 +89,6 @@
                 (:mail-adres :string ,(s-prefix "ext:mailAdresVoorNotificaties")))
   :has-one `((werkingsgebied :via ,(s-prefix "besluit:werkingsgebied")
                              :as "werkingsgebied")
-             (werkingsgebied :via ,(s-prefix "ext:inProvincie")
-                             :as "provincie")
              (vestiging      :via ,(s-prefix "org:hasPrimarySite")
                              :as "primary-site")
              (bestuurseenheid-classificatie-code :via ,(s-prefix "besluit:classificatie")

--- a/config/resources/slave-contact-domain.lisp
+++ b/config/resources/slave-contact-domain.lisp
@@ -27,6 +27,8 @@
                 (:volledig-adres :string ,(s-prefix "locn:fullAddress"))
                 (:adres-register-id :number ,(s-prefix "lblodlg:adresRegisterId"))
                 (:adres-register-uri :url ,(s-prefix "adres:verwijstNaar")))
+  :has-one `((concept :via ,(s-prefix "adres:adresIsGelegenIn")
+                      :as "provincie"))
   :features '(include-uri)
   :resource-base (s-url "http://data.lblod.info/id/adressen/")
   :on-path "adressen")

--- a/config/resources/slave-organisatie-domain.lisp
+++ b/config/resources/slave-organisatie-domain.lisp
@@ -2,8 +2,8 @@
 ;; this is a shared domain file, maintained in https://github.com/lblod/domain-files
 (define-resource vestiging ()
   :class (s-prefix "org:Site")
-  :has-one `((contact-punt :via ,(s-prefix "schema:contactPoint")
-                           :as "vestigingsadres"))
+  :has-one `((adres        :via ,(s-prefix "organisatie:bestaatUit")
+                           :as "address"))
   :resource-base (s-url "http://data.lblod.info/id/vestiging/")
   :features '(include-uri)
   :on-path "vestigingen"

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -79,13 +79,17 @@
           "http://purl.org/pav/createdBy"
         ],
         "province": [
-          "http://purl.org/pav/createdBy",
-          "http://mu.semte.ch/vocabularies/ext/inProvincie",
+          "http://purl.org/pav/createdBy", 
+          "http://www.w3.org/ns/org#hasPrimarySite",
+          "https://data.vlaanderen.be/ns/organisatie#bestaatUit",
+          "https://data.vlaanderen.be/ns/adres#adresIsGelegenIn",
           "http://www.w3.org/2000/01/rdf-schema#label"
         ],
         "provinceURI": [
-          "http://purl.org/pav/createdBy",
-          "http://mu.semte.ch/vocabularies/ext/inProvincie"
+          "http://purl.org/pav/createdBy", 
+          "http://www.w3.org/ns/org#hasPrimarySite",
+          "https://data.vlaanderen.be/ns/organisatie#bestaatUit",
+          "https://data.vlaanderen.be/ns/adres#adresIsGelegenIn"
         ],
         "administrativeUnitClassification": [
           "http://purl.org/pav/createdBy",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ x-logging:
 
 services:
   toezicht-abb:
-    image: lblod/frontend-toezicht-abb:0.29.1
+    image: lblod/frontend-toezicht-abb:0.30.1
     volumes:
       - ./config/frontend:/config
     labels:

--- a/scripts/reset-elastic.sh
+++ b/scripts/reset-elastic.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+version=$(docker compose version)
+
+if [ $? -eq 0 ]; then
+    DRC_COMMAND="docker compose"
+else
+    DRC_COMMAND="docker-compose"
+fi
+
+echo "warning this will run queries on the triplestore and delete containers, you have 3 seconds to press ctrl+c"
+sleep 3
+eval "$DRC_COMMAND rm -fs elasticsearch search"
+sudo rm -rf data/elasticsearch/
+eval "$DRC_COMMAND exec -T triplestore isql-v <<EOF
+SPARQL DELETE WHERE {   GRAPH <http://mu.semte.ch/authorization> {     ?s ?p ?o.   } };
+exec('checkpoint');
+exit;
+EOF"
+eval "$DRC_COMMAND up -d --remove-orphans"


### PR DESCRIPTION
The province data is no longer behind ext:provincie on bestuurseenheden. It is now behind the adres of the primary site of the bestuurseenheid. This PR implements this change.

JIRA: https://binnenland.atlassian.net/browse/DL-6429