### PR TITLE
DL-6704: Remove obsolete submissions via migrations (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+
+## Unreleased 
+
+### General
+
+- Remove obsolete submissions [DL-6704]
+
+### Deploy Notes
+
+```
+drc restart migrations && drc logs -ft --tail=200 migrations
+```
+
 ## v1.47.2 (2025-08-27)
  - Bufix: remove obsolete `provincie` call 
     - See https://github.com/lblod/frontend-toezicht-abb/pull/67 [DL-6777]

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812092528-remove-obsolete-submissions-light-queries/20250812092528-remove-obsolete-submissions-gemeente-provincie.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812092528-remove-obsolete-submissions-light-queries/20250812092528-remove-obsolete-submissions-gemeente-provincie.sparql
@@ -1,0 +1,40 @@
+DELETE {
+  GRAPH ?g {
+    ?submission ?submissionP ?submissionO.
+    ?subject ?subjectP ?subjectO.
+    ?formData ?formDataP ?formDataO.
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/4f938e44-8bce-4d3a-b5a7-b84754fe981a>
+    <https://data.vlaanderen.be/id/concept/BesluitType/df261490-cc74-4f80-b783-41c35e720b46>
+    <https://data.vlaanderen.be/id/concept/BesluitType/3fcf7dba-2e5b-4955-a489-6dd8285c013b>
+    <https://data.vlaanderen.be/id/concept/BesluitType/e6425cd1-26f2-4cd8-aa0f-1e9b65619c3a>
+    <https://data.vlaanderen.be/id/concept/BesluitType/e2928231-d377-48c7-98b4-3bb2f7de65db>
+    <https://data.vlaanderen.be/id/concept/BesluitType/8d8a75bf-f639-44ae-bcce-50b8f760cc3c>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/863caf68-97c9-4ee0-adb5-620577ea8146>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/24743b26-e0fb-4c14-8c82-5cd271289b0e>
+    <https://data.vlaanderen.be/id/concept/BesluitType/b25faa84-3ab5-47ae-98c0-1b389c77b827>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+                <http://www.w3.org/ns/prov#generated> ?formData;
+        	<http://purl.org/pav/createdBy> ?createdBy;
+                ?submissionP ?submissionO;
+                <http://purl.org/dc/terms/subject> ?subject.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              ?formDataP ?formDataO;
+              <http://purl.org/dc/terms/hasPart> ?remoteDataObject.
+
+    ?subject ?subjectP ?subjectO.
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+    ?createdBy <http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812092528-remove-obsolete-submissions-light-queries/20250812094007-remove-obsolete-submissions-centraal-bestuur.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812092528-remove-obsolete-submissions-light-queries/20250812094007-remove-obsolete-submissions-centraal-bestuur.sparql
@@ -1,0 +1,33 @@
+DELETE {
+  GRAPH ?g {
+    ?submission ?submissionP ?submissionO.
+    ?subject ?subjectP ?subjectO.
+    ?formData ?formDataP ?formDataO.
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/18833df2-8c9e-4edd-87fd-b5c252337349>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/ce569d3d-25ff-4ce9-a194-e77113597e29>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/2c9ada23-1229-4c7e-a53e-acddc9014e4e>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+                <http://www.w3.org/ns/prov#generated> ?formData;
+        	<http://purl.org/pav/createdBy> ?createdBy;
+                ?submissionP ?submissionO;
+                <http://purl.org/dc/terms/subject> ?subject.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              ?formDataP ?formDataO;
+              <http://purl.org/dc/terms/hasPart> ?remoteDataObject.
+
+    ?subject ?subjectP ?subjectO.
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+    ?createdBy <http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812092528-remove-obsolete-submissions-light-queries/20250812094012-remove-obsolete-submissions-bestuur.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812092528-remove-obsolete-submissions-light-queries/20250812094012-remove-obsolete-submissions-bestuur.sparql
@@ -1,0 +1,33 @@
+DELETE {
+  GRAPH ?g {
+    ?submission ?submissionP ?submissionO.
+    ?subject ?subjectP ?subjectO.
+    ?formData ?formDataP ?formDataO.
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/a970c99d-c06c-4942-9815-153bf3e87df2>
+    <https://data.vlaanderen.be/id/concept/BesluitType/d463b6d1-c207-4c1a-8c08-f2c7dd1fa53b>
+    <https://data.vlaanderen.be/id/concept/BesluitType/d85218e2-a75f-4a30-9182-512b5c9dd1b2>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+                <http://www.w3.org/ns/prov#generated> ?formData;
+        	<http://purl.org/pav/createdBy> ?createdBy;
+                ?submissionP ?submissionO;
+                <http://purl.org/dc/terms/subject> ?subject.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              ?formDataP ?formDataO;
+              <http://purl.org/dc/terms/hasPart> ?remoteDataObject.
+
+    ?subject ?subjectP ?subjectO.
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+    ?createdBy <http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812092528-remove-obsolete-submissions-light-queries/20250812094016-remove-obsolete-submissions-besturen.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812092528-remove-obsolete-submissions-light-queries/20250812094016-remove-obsolete-submissions-besturen.sparql
@@ -1,0 +1,33 @@
+DELETE {
+  GRAPH ?g {
+    ?submission ?submissionP ?submissionO.
+    ?subject ?subjectP ?subjectO.
+    ?formData ?formDataP ?formDataO.
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/41a09f6c-7964-4777-8375-437ef61ed946>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3a3ea43f-6631-4a7d-94c6-3a77a445d450>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+                <http://www.w3.org/ns/prov#generated> ?formData;
+        	<http://purl.org/pav/createdBy> ?createdBy;
+                ?submissionP ?submissionO;
+                <http://purl.org/dc/terms/subject> ?subject.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              ?formDataP ?formDataO;
+              <http://purl.org/dc/terms/hasPart> ?remoteDataObject.
+
+    ?subject ?subjectP ?subjectO.
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+    ?createdBy <http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812092528-remove-obsolete-submissions-light-queries/20250812094025-remove-obsolete-submissions-besturen-all-sent-by.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812092528-remove-obsolete-submissions-light-queries/20250812094025-remove-obsolete-submissions-besturen-all-sent-by.sparql
@@ -1,0 +1,35 @@
+DELETE {
+  GRAPH ?g {
+    ?submission ?submissionP ?submissionO.
+    ?subject ?subjectP ?subjectO.
+    ?formData ?formDataP ?formDataO.
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/802a7e56-54f8-488d-b489-4816321fb9ae>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213>
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+                <http://www.w3.org/ns/prov#generated> ?formData;
+        	<http://purl.org/pav/createdBy> ?createdBy;
+                ?submissionP ?submissionO;
+                <http://purl.org/dc/terms/subject> ?subject.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              ?formDataP ?formDataO;
+              <http://purl.org/dc/terms/hasPart> ?remoteDataObject.
+
+    ?subject ?subjectP ?subjectO.
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+    ?createdBy <http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812092528-remove-obsolete-submissions-light-queries/20250812094034-remove-obsolete-submissions-representatief-orgaan.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812092528-remove-obsolete-submissions-light-queries/20250812094034-remove-obsolete-submissions-representatief-orgaan.sparql
@@ -1,0 +1,37 @@
+DELETE {
+  GRAPH ?g {
+    ?submission ?submissionP ?submissionO.
+    ?subject ?subjectP ?subjectO.
+    ?formData ?formDataP ?formDataO.
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/2b12630f-8c4e-40a4-8a61-a0c45621a1e6>
+    <https://data.vlaanderen.be/id/concept/BesluitType/0fc2c27d-a03c-4e3f-9db1-f10f026f76f8>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a>
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+                <http://www.w3.org/ns/prov#generated> ?formData;
+        	<http://purl.org/pav/createdBy> ?createdBy;
+                ?submissionP ?submissionO;
+                <http://purl.org/dc/terms/subject> ?subject.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              ?formDataP ?formDataO;
+              <http://purl.org/dc/terms/hasPart> ?remoteDataObject.
+
+    ?subject ?subjectP ?subjectO.
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+    ?createdBy <http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812124800-remove-obsolete-submissions-notulen/20250901130733-remove-obsolete-submissions-notulen-subject.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812124800-remove-obsolete-submissions-notulen/20250901130733-remove-obsolete-submissions-notulen-subject.sparql
@@ -1,0 +1,22 @@
+DELETE {
+  GRAPH ?g {
+    ?subject ?subjectP ?subjectO
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/8e791b27-7600-4577-b24e-c7c29e0eb773>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+      <http://www.w3.org/ns/prov#generated> ?formData;
+      <http://purl.org/pav/createdBy>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri;
+                <http://purl.org/dc/terms/subject> ?subject.
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri.
+    ?subject ?subjectP ?subjectO.
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812124800-remove-obsolete-submissions-notulen/20250901130837-remove-obsolete-submissions-notulen-remoteDataObject.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812124800-remove-obsolete-submissions-notulen/20250901130837-remove-obsolete-submissions-notulen-remoteDataObject.sparql
@@ -1,0 +1,25 @@
+DELETE {
+  GRAPH ?g {
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/8e791b27-7600-4577-b24e-c7c29e0eb773>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+      <http://www.w3.org/ns/prov#generated> ?formData;
+      <http://purl.org/pav/createdBy>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              <http://purl.org/dc/terms/hasPart> ?remoteDataObject.
+              
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812124800-remove-obsolete-submissions-notulen/20250901131414-remove-obsolete-submissions-notulen-rest.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250812124800-remove-obsolete-submissions-notulen/20250901131414-remove-obsolete-submissions-notulen-rest.sparql
@@ -1,0 +1,27 @@
+DELETE {
+  GRAPH ?g {
+    ?submission ?submissionP ?submissionO.
+    ?formData ?formDataP ?formDataO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/8e791b27-7600-4577-b24e-c7c29e0eb773>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+                <http://www.w3.org/ns/prov#generated> ?formData;
+        	<http://purl.org/pav/createdBy> ?createdBy;
+                ?submissionP ?submissionO.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              ?formDataP ?formDataO.
+
+    ?createdBy <http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+  }
+}
+

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133012-remove-obsolete-migrations-meerjarenplan/20250901133012-remove-obsolete-migrations-meerjarenplan-subject.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133012-remove-obsolete-migrations-meerjarenplan/20250901133012-remove-obsolete-migrations-meerjarenplan-subject.sparql
@@ -1,0 +1,21 @@
+DELETE {
+  GRAPH ?g {
+    ?subject ?subjectP ?subjectO
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+      <http://www.w3.org/ns/prov#generated> ?formData;
+      <http://purl.org/pav/createdBy>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri;
+                <http://purl.org/dc/terms/subject> ?subject.
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri.
+    ?subject ?subjectP ?subjectO.
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133012-remove-obsolete-migrations-meerjarenplan/20250901133018-remove-obsolete-migrations-meerjarenplan-remoteDataObject.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133012-remove-obsolete-migrations-meerjarenplan/20250901133018-remove-obsolete-migrations-meerjarenplan-remoteDataObject.sparql
@@ -1,0 +1,24 @@
+DELETE {
+  GRAPH ?g {
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+      <http://www.w3.org/ns/prov#generated> ?formData;
+      <http://purl.org/pav/createdBy>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              <http://purl.org/dc/terms/hasPart> ?remoteDataObject.
+              
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133012-remove-obsolete-migrations-meerjarenplan/20250901133023-remove-obsolete-migrations-meerjarenplan-rest.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133012-remove-obsolete-migrations-meerjarenplan/20250901133023-remove-obsolete-migrations-meerjarenplan-rest.sparql
@@ -1,0 +1,26 @@
+DELETE {
+  GRAPH ?g {
+    ?submission ?submissionP ?submissionO.
+    ?formData ?formDataP ?formDataO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+                <http://www.w3.org/ns/prov#generated> ?formData;
+        	<http://purl.org/pav/createdBy> ?createdBy;
+                ?submissionP ?submissionO.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              ?formDataP ?formDataO.
+
+    ?createdBy <http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+  }
+}
+

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133116-remove-obsolete-migrations-jaarrekeningBestuurEre/20250901133116-remove-obsolete-migrations-jaarrekeningBestuurEre-subject.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133116-remove-obsolete-migrations-jaarrekeningBestuurEre/20250901133116-remove-obsolete-migrations-jaarrekeningBestuurEre-subject.sparql
@@ -1,0 +1,21 @@
+DELETE {
+  GRAPH ?g {
+    ?subject ?subjectP ?subjectO
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/672bf096-dccd-40af-ab60-bd7de15cc461>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+      <http://www.w3.org/ns/prov#generated> ?formData;
+      <http://purl.org/pav/createdBy>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri;
+                <http://purl.org/dc/terms/subject> ?subject.
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri.
+    ?subject ?subjectP ?subjectO.
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133116-remove-obsolete-migrations-jaarrekeningBestuurEre/20250901133122-remove-obsolete-migrations-jaarrekeningBestuurEre-remoteDataObject.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133116-remove-obsolete-migrations-jaarrekeningBestuurEre/20250901133122-remove-obsolete-migrations-jaarrekeningBestuurEre-remoteDataObject.sparql
@@ -1,0 +1,24 @@
+DELETE {
+  GRAPH ?g {
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/672bf096-dccd-40af-ab60-bd7de15cc461>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+      <http://www.w3.org/ns/prov#generated> ?formData;
+      <http://purl.org/pav/createdBy>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              <http://purl.org/dc/terms/hasPart> ?remoteDataObject.
+              
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133116-remove-obsolete-migrations-jaarrekeningBestuurEre/20250901133126-remove-obsolete-migrations-jaarrekeningBestuurEre-rest.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133116-remove-obsolete-migrations-jaarrekeningBestuurEre/20250901133126-remove-obsolete-migrations-jaarrekeningBestuurEre-rest.sparql
@@ -1,0 +1,26 @@
+DELETE {
+  GRAPH ?g {
+    ?submission ?submissionP ?submissionO.
+    ?formData ?formDataP ?formDataO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/672bf096-dccd-40af-ab60-bd7de15cc461>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+                <http://www.w3.org/ns/prov#generated> ?formData;
+        	<http://purl.org/pav/createdBy> ?createdBy;
+                ?submissionP ?submissionO.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              ?formDataP ?formDataO.
+
+    ?createdBy <http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+  }
+}
+

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133239-remove-obsolete-migrations-jaarrekening/20250901133239-remove-obsolete-migrations-jaarrekening-subject.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133239-remove-obsolete-migrations-jaarrekening/20250901133239-remove-obsolete-migrations-jaarrekening-subject.sparql
@@ -1,0 +1,21 @@
+DELETE {
+  GRAPH ?g {
+    ?subject ?subjectP ?subjectO
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+      <http://www.w3.org/ns/prov#generated> ?formData;
+      <http://purl.org/pav/createdBy>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri;
+                <http://purl.org/dc/terms/subject> ?subject.
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri.
+    ?subject ?subjectP ?subjectO.
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133239-remove-obsolete-migrations-jaarrekening/20250901133247-remove-obsolete-migrations-jaarrekening-remoteDataObject.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133239-remove-obsolete-migrations-jaarrekening/20250901133247-remove-obsolete-migrations-jaarrekening-remoteDataObject.sparql
@@ -1,0 +1,23 @@
+DELETE {
+  GRAPH ?g {
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+      <http://www.w3.org/ns/prov#generated> ?formData;
+      <http://purl.org/pav/createdBy>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              <http://purl.org/dc/terms/hasPart> ?remoteDataObject.
+              
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133239-remove-obsolete-migrations-jaarrekening/20250901133252-remove-obsolete-migrations-jaarrekening-rest.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133239-remove-obsolete-migrations-jaarrekening/20250901133252-remove-obsolete-migrations-jaarrekening-rest.sparql
@@ -1,0 +1,26 @@
+DELETE {
+  GRAPH ?g {
+    ?submission ?submissionP ?submissionO.
+    ?formData ?formDataP ?formDataO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+                <http://www.w3.org/ns/prov#generated> ?formData;
+        	<http://purl.org/pav/createdBy> ?createdBy;
+                ?submissionP ?submissionO.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              ?formDataP ?formDataO.
+
+    ?createdBy <http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+  }
+}
+

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133341-remove-obsolete-migrations-adviesJaarrekeningEre/20250901133341-remove-obsolete-migrations-adviesJaarrekeningEre-subject.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133341-remove-obsolete-migrations-adviesJaarrekeningEre/20250901133341-remove-obsolete-migrations-adviesJaarrekeningEre-subject.sparql
@@ -1,0 +1,22 @@
+DELETE {
+  GRAPH ?g {
+    ?subject ?subjectP ?subjectO
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+      <http://www.w3.org/ns/prov#generated> ?formData;
+      <http://purl.org/pav/createdBy>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri;
+                <http://purl.org/dc/terms/subject> ?subject.
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri.
+    ?subject ?subjectP ?subjectO.
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133341-remove-obsolete-migrations-adviesJaarrekeningEre/20250901133346-remove-obsolete-migrations-adviesJaarrekeningEre-remoteDataObject.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133341-remove-obsolete-migrations-adviesJaarrekeningEre/20250901133346-remove-obsolete-migrations-adviesJaarrekeningEre-remoteDataObject.sparql
@@ -1,0 +1,24 @@
+DELETE {
+  GRAPH ?g {
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+      <http://www.w3.org/ns/prov#generated> ?formData;
+      <http://purl.org/pav/createdBy>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              <http://purl.org/dc/terms/hasPart> ?remoteDataObject.
+              
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133341-remove-obsolete-migrations-adviesJaarrekeningEre/20250901133405-remove-obsolete-migrations-adviesJaarrekeningEre-rest.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133341-remove-obsolete-migrations-adviesJaarrekeningEre/20250901133405-remove-obsolete-migrations-adviesJaarrekeningEre-rest.sparql
@@ -1,0 +1,27 @@
+DELETE {
+  GRAPH ?g {
+    ?submission ?submissionP ?submissionO.
+    ?formData ?formDataP ?formDataO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+                <http://www.w3.org/ns/prov#generated> ?formData;
+        	<http://purl.org/pav/createdBy> ?createdBy;
+                ?submissionP ?submissionO.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              ?formDataP ?formDataO.
+
+    ?createdBy <http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+  }
+}
+

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133449-remove-obsolete-migrations-eindrekening/20250901133449-remove-obsolete-migrations-eindrekening-subject.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133449-remove-obsolete-migrations-eindrekening/20250901133449-remove-obsolete-migrations-eindrekening-subject.sparql
@@ -1,0 +1,21 @@
+DELETE {
+  GRAPH ?g {
+    ?subject ?subjectP ?subjectO
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/54b61cbd-349f-41c4-9c8a-7e8e67d08347>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+      <http://www.w3.org/ns/prov#generated> ?formData;
+      <http://purl.org/pav/createdBy>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri;
+                <http://purl.org/dc/terms/subject> ?subject.
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri.
+    ?subject ?subjectP ?subjectO.
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133449-remove-obsolete-migrations-eindrekening/20250901133455-remove-obsolete-migrations-eindrekening-remoteDataObject.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133449-remove-obsolete-migrations-eindrekening/20250901133455-remove-obsolete-migrations-eindrekening-remoteDataObject.sparql
@@ -1,0 +1,24 @@
+DELETE {
+  GRAPH ?g {
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/54b61cbd-349f-41c4-9c8a-7e8e67d08347>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+      <http://www.w3.org/ns/prov#generated> ?formData;
+      <http://purl.org/pav/createdBy>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              <http://purl.org/dc/terms/hasPart> ?remoteDataObject.
+              
+    ?remoteDataObject ?remoteDataObjectP ?remoteDataObjectO.
+
+  }
+}

--- a/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133449-remove-obsolete-migrations-eindrekening/20250901133458-remove-obsolete-migrations-eindrekening-rest.sparql
+++ b/config/migrations/2025/20250812092528-remove-obsolete-submissions-migrations/20250901133449-remove-obsolete-migrations-eindrekening/20250901133458-remove-obsolete-migrations-eindrekening-rest.sparql
@@ -1,0 +1,26 @@
+DELETE {
+  GRAPH ?g {
+    ?submission ?submissionP ?submissionO.
+    ?formData ?formDataP ?formDataO.
+  }
+}
+WHERE {
+  VALUES ?besluitTypeUri {
+    <https://data.vlaanderen.be/id/concept/BesluitType/54b61cbd-349f-41c4-9c8a-7e8e67d08347>
+  }
+  VALUES ?sentByUri {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+  }
+  GRAPH ?g {
+    ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+                <http://www.w3.org/ns/prov#generated> ?formData;
+        	<http://purl.org/pav/createdBy> ?createdBy;
+                ?submissionP ?submissionO.
+
+    ?formData <http://mu.semte.ch/vocabularies/ext/decisionType> ?besluitTypeUri;
+              ?formDataP ?formDataO.
+
+    ?createdBy <http://data.vlaanderen.be/ns/besluit#classificatie> ?sentByUri.
+  }
+}
+


### PR DESCRIPTION
Made a few migrations to remove all chosen submissions. See the excel in the ticket for which ones that should be. Included migrations are:

Per besluittype + sent by combo the lighter migrations combines For the heaver migrations I split them up so they would be able to run. These are in seperate folders

### Ticket
DL-6704