### PR TITLE
DL-7272-DL-7260: added migration to remove empty submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## Unreleased
+- Removed empty submissions [DL-7260] [DL-7272]
+
+### Deploy instructions
+```
+drc restart migrations
+```
+
 ## v1.51.0 (2025-12-23)
 - Databank Toezicht ABB: Include KBO-number in bestuurseenheden filter [DL-6558]
 - Remove all submissions from eredienst besturen. [DL-6997]

--- a/config/migrations/2026/20260331142919-cleanup-empty-submissions.sparql
+++ b/config/migrations/2026/20260331142919-cleanup-empty-submissions.sparql
@@ -1,0 +1,43 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX schema: <http://schema.org/>
+
+DELETE {
+  GRAPH ?g {
+    ?submission ?sp ?so .
+    ?submissionDocument ?sdp ?sdo .
+    ?pFile ?pp ?po .
+    ?formData ?fp ?fo .
+    ?review ?rp ?ro .
+  }
+}
+WHERE {
+  VALUES ?submission {
+    <http://data.lblod.info/submissions/69BBE08C5324D71F255A7AFA>
+    <http://data.lblod.info/submissions/69BAD4C15324D71F255A7A73>
+    <http://data.lblod.info/submissions/69BBEA4B5324D71F255A7B01>
+    <http://data.lblod.info/submissions/69BC099B5324D71F255A7B33>
+  }
+
+  GRAPH ?g {
+    {
+      ?submission ?sp ?so .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument ?sdp ?sdo .
+    } UNION {
+      ?submission dct:subject ?submissionDocument .
+      ?submissionDocument dct:source ?pFile .
+      ?pFile ?pp ?po .
+      FILTER NOT EXISTS {
+        ?pFile dct:type <http://data.lblod.gift/concepts/form-file-type> .
+      }
+    } UNION {
+      ?submission prov:generated ?formData .
+      ?formData ?fp ?fo .
+    } UNION {
+      ?review schema:itemReviewed ?submission .
+      ?review ?rp ?ro .
+    }
+  }
+}


### PR DESCRIPTION
- Added a migration that removes the data from the empty submissions mentioned in the tickets.